### PR TITLE
`Metatensor.torch.atomistic` is now `metatomic.torch`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(metatensor_lj_test CXX)
+project(metatomic_lj_test CXX)
 
 # FindCUDNN.cmake distributed with PyTorch is a bit broken, so we have a
 # fixed version in `cmake/FindCUDNN.cmake`

--- a/README.md
+++ b/README.md
@@ -1,31 +1,31 @@
-# Lennard-Jones potential as a metatensor atomistic model
+# Lennard-Jones potential as a metatomic energy model
 
 This repository contains an implementation of the classic Lennard-Jones
-potential as a [metatensor atomistic
+potential as a [metatomic
 model](https://lab-cosmo.github.io/metatensor/latest/atomistic/index.html).
 
-This is intended to be used when testing the integration of metatensor atomistic
-models with various simulation engines; but can also serve as a relatively
-complete example of how to write your own models and use neighbor lists.
+This is intended to be used when testing the integration of metatomic models
+with various simulation engines; but can also serve as a relatively complete
+example of how to write your own models and use neighbor lists.
 
 ### Installation
 
 ```bash
-pip install git+https://github.com/Luthaf/metatensor-lj-test
+pip install git+https://github.com/metatensor/lj-test
 
 # if you are working on Linux or Windows and DO NOT have a CUDA GPU
-pip install --extra-index-url=https://download.pytorch.org/whl/cpu git+https://github.com/Luthaf/metatensor-lj-test
+pip install --extra-index-url=https://download.pytorch.org/whl/cpu git+https://github.com/metatensor/lj-test
 ```
 
 ### API
 
 ```python
-import metatensor_lj_test
+import metatomic_lj_test
 
 # `with_extension` controls wether the model uses custom
 # TorchScript operators defined in a C++ extension library
 # or a pure PyTorch implementation
-model = metatensor_lj_test.lennard_jones_model(
+model = metatomic_lj_test.lennard_jones_model(
     atomic_type=12,
     cutoff=3.4,
     sigma=1.5,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
-name = "metatensor-lj-test"
-description = "Package for testing metatensor model integration"
+name = "metatomic-lj-test"
+description = "Package for testing metatomic model integration"
 dynamic = ["version"]
 dependencies = [
     "torch >=1.12",
-    "metatensor-torch >=0.6.0,<0.8.0"
+    "metatomic-torch >=0.1.0,<0.0.0"
 ]
 
 [build-system]
@@ -15,6 +15,5 @@ requires = [
     "setuptools-scm",
     "torch >=1.12"
 ]
-
 
 [tool.setuptools_scm]

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ class cmake_ext(build_ext):
         source_dir = ROOT
         build_dir = os.path.join(ROOT, "build", "cmake-build")
         install_dir = os.path.join(
-            os.path.realpath(self.build_lib), "metatensor_lj_test"
+            os.path.realpath(self.build_lib), "metatomic_lj_test"
         )
 
         os.makedirs(build_dir, exist_ok=True)
@@ -81,14 +81,14 @@ class cmake_ext(build_ext):
 if __name__ == "__main__":
     setup(
         ext_modules=[
-            Extension(name="metatensor_lj_test", sources=[]),
+            Extension(name="metatomic_lj_test", sources=[]),
         ],
         cmdclass={
             "build_ext": cmake_ext,
         },
         package_data={
-            "metatensor_lj_test": [
-                "metatensor_lj_test/lib/*",
+            "metatomic_lj_test": [
+                "metatomic_lj_test/lib/*",
             ]
         },
     )

--- a/src/extension.cpp
+++ b/src/extension.cpp
@@ -23,7 +23,7 @@ torch::Tensor lennard_jones(
     return energies;
 }
 
-TORCH_LIBRARY(metatensor_lj_test, m) {
+TORCH_LIBRARY(metatomic_lj_test, m) {
     m.def(
         "lennard_jones(Tensor pairs, Tensor distances, int n_atoms, float epsilon, float sigma, float shift) -> Tensor",
         lennard_jones

--- a/src/metatomic_lj_test/__init__.py
+++ b/src/metatomic_lj_test/__init__.py
@@ -1,5 +1,5 @@
-from metatensor.torch.atomistic import (
-    MetatensorAtomisticModel,
+from metatomic.torch import (
+    AtomisticModel,
     ModelCapabilities,
     ModelMetadata,
     ModelOutput,
@@ -16,8 +16,8 @@ def lennard_jones_model(
     with_extension,
 ):
     """
-    Get a :py:class:`MetatensorAtomisticModel` corresponding to a shifted Lennard-Jones
-    potential for the given ``atomic_type``.
+    Get a metatomic model corresponding to a shifted Lennard-Jones potential for the
+    given ``atomic_type``.
 
     The energy for this model is a sum over all pairs within the cutoff of:
 
@@ -66,7 +66,7 @@ def lennard_jones_model(
                 unit=energy_unit,
                 per_atom=True,
                 explicit_gradients=[],
-            ), # This is a dummy ensemble for testing, returning the same energy many times
+            ),  # This is a dummy ensemble for testing, returning the same energy many times
             "energy_uncertainty": ModelOutput(
                 quantity="energy",
                 unit=energy_unit,
@@ -93,17 +93,17 @@ def lennard_jones_model(
     metadata = ModelMetadata(
         name="Test Lennard-Jones" + (" (with extension)" if with_extension else ""),
         description="""Minimal shifted Lennard-Jones potential, to be used when testing
-the integration of metatensor atomistic models with various simulation engines.""",
+the integration of metatomic models with various simulation engines.""",
         authors=["Guillaume Fraux <guillaume.fraux@epfl.ch>"],
         references={
             "model": [
-                "https://github.com/luthaf/metatensor-lj-test",
+                "https://github.com/metatensor/lj-test",
             ],
             "implementation": [
-                "https://github.com/lab-cosmo/metatensor",
+                "https://github.com/metatensor/metatomic",
             ],
         },
     )
 
     model.eval()
-    return MetatensorAtomisticModel(model, metadata, capabilities)
+    return AtomisticModel(model, metadata, capabilities)

--- a/src/metatomic_lj_test/extension.py
+++ b/src/metatomic_lj_test/extension.py
@@ -4,36 +4,38 @@ from typing import Dict, List, Optional
 
 import torch
 from metatensor.torch import Labels, TensorBlock, TensorMap
-from metatensor.torch.atomistic import ModelOutput, NeighborListOptions, System
+from metatomic.torch import ModelOutput, NeighborListOptions, System
 
 _HERE = os.path.dirname(__file__)
 
 
 def _lib_path():
     if sys.platform.startswith("darwin"):
-        path = os.path.join(_HERE, "lib", "libmetatensor_lj_test.dylib")
+        path = os.path.join(_HERE, "lib", "libmetatomic_lj_test.dylib")
     elif sys.platform.startswith("linux"):
-        path = os.path.join(_HERE, "lib", "libmetatensor_lj_test.so")
+        path = os.path.join(_HERE, "lib", "libmetatomic_lj_test.so")
     elif sys.platform.startswith("win"):
-        path = os.path.join(_HERE, "bin", "metatensor_lj_test.dll")
+        path = os.path.join(_HERE, "bin", "metatomic_lj_test.dll")
     else:
         raise ImportError("Unknown platform. Please edit this file")
 
     if os.path.isfile(path):
         return path
 
-    raise ImportError("Could not find metatensor_torch shared library at " + path)
+    raise ImportError("Could not find metatomic_lj shared library at " + path)
 
 
 class LennardJonesExtension(torch.nn.Module):
     """
     Implementation of Lennard-Jones potential using a custom TorchScript extension,
-    following the metatensor atomistic models interface.
+    following the metatomic models interface.
     """
 
     def __init__(self, cutoff, epsilon, sigma):
         super().__init__()
-        self._nl_options = NeighborListOptions(cutoff=cutoff, full_list=False, strict=True)
+        self._nl_options = NeighborListOptions(
+            cutoff=cutoff, full_list=False, strict=True
+        )
 
         self._epsilon = epsilon
         self._sigma = sigma
@@ -85,7 +87,7 @@ class LennardJonesExtension(torch.nn.Module):
             distances = neighbors.values.reshape(-1, 3)
 
             # call the custom operator
-            energy = torch.ops.metatensor_lj_test.lennard_jones(
+            energy = torch.ops.metatomic_lj_test.lennard_jones(
                 pairs=pairs,
                 distances=distances,
                 n_atoms=len(system),

--- a/src/metatomic_lj_test/pure.py
+++ b/src/metatomic_lj_test/pure.py
@@ -2,18 +2,20 @@ from typing import Dict, List, Optional
 
 import torch
 from metatensor.torch import Labels, TensorBlock, TensorMap
-from metatensor.torch.atomistic import ModelOutput, NeighborListOptions, System
+from metatomic.torch import ModelOutput, NeighborListOptions, System
 
 
 class LennardJonesPurePyTorch(torch.nn.Module):
     """
-    Pure PyTorch implementation of Lennard-Jones potential, following metatensor
-    atomistic models interface.
+    Pure PyTorch implementation of Lennard-Jones potential, following metatomic models
+    interface.
     """
 
     def __init__(self, cutoff, epsilon, sigma):
         super().__init__()
-        self._nl_options = NeighborListOptions(cutoff=cutoff, full_list=False, strict=True)
+        self._nl_options = NeighborListOptions(
+            cutoff=cutoff, full_list=False, strict=True
+        )
 
         self._epsilon = epsilon
         self._sigma = sigma


### PR DESCRIPTION
~DO NOT MERGE, this exists to be able to run tests on the WIP metatomic repository~